### PR TITLE
Validation lots

### DIFF
--- a/contracts/Project.sol
+++ b/contracts/Project.sol
@@ -165,7 +165,7 @@ contract Project {
         tokenRegistryAddress = _tokenRegistry;
         projectRegistryAddress = msg.sender;
         validationReward = _cost * 5 / 100;
-        weiCost = _cost + validateReward;
+        weiCost = _cost + validationReward;
 
         // This is broken math
         reputationCost = _costProportion * ReputationRegistry(_reputationRegistry).totalSupply() / 10000000000;
@@ -334,6 +334,7 @@ contract Project {
     @dev Only callable before the staking period of a proposed project ends (state must still be 1)
     @param _staker Address of the staker who is unstaking
     @param _tokens Amount of tokens to unstake on the project
+    @param _distributeTokenAddress Address of distribute token contract
     @return The amount of ether to deduct from the projects balance
 
     */
@@ -392,6 +393,7 @@ contract Project {
     @notice Transfer `_reward` wei as reward for completing a task to `_rewardee
     @dev Only callable by the Reputation Registry initialized during construction, to maintain control flow
     @param _rewardee The account who claimed and completed the task.
+    @param _reward The amount of wei to transfer.
     */
     function transferWeiReward(address _rewardee, uint _reward) external onlyTRorRR {
         require(_reward <= weiBal);

--- a/contracts/Project.sol
+++ b/contracts/Project.sol
@@ -38,7 +38,9 @@ contract Project {
       uint validateStatePeriod,
       uint voteCommitPeriod,
       uint voteRevealPeriod,
-      uint passThreshold
+      uint passThreshold,
+      uint proposerCost,
+      uint validationReward
     );
 
     // =====================================================================
@@ -201,6 +203,8 @@ contract Project {
           voteCommitPeriod,
           voteRevealPeriod,
           passThreshold
+          proposedCost,
+          validateReward
         );
 
     }

--- a/contracts/Project.sol
+++ b/contracts/Project.sol
@@ -78,6 +78,7 @@ contract Project {
     uint256 public nextDeadline;
     uint256 public weiCost;
     uint256 public reputationCost;
+    uint256 public validationReward;
     bytes public ipfsHash;
 
     uint256 public tokensStaked;
@@ -107,6 +108,11 @@ contract Project {
 
     modifier onlyRR() {
         require(msg.sender == reputationRegistryAddress);
+        _;
+    }
+
+    modifier onlyTRorRR() {
+        require(msg.sender == tokenRegistryAddress || msg.sender == reputationRegistryAddress);
         _;
     }
 
@@ -158,7 +164,9 @@ contract Project {
         reputationRegistryAddress = _reputationRegistry;
         tokenRegistryAddress = _tokenRegistry;
         projectRegistryAddress = msg.sender;
-        weiCost = _cost;
+        validationReward = _cost * 5 / 100;
+        weiCost = _cost + validateReward;
+
         // This is broken math
         reputationCost = _costProportion * ReputationRegistry(_reputationRegistry).totalSupply() / 10000000000;
         state = 1;
@@ -385,7 +393,7 @@ contract Project {
     @dev Only callable by the Reputation Registry initialized during construction, to maintain control flow
     @param _rewardee The account who claimed and completed the task.
     */
-    function transferWeiReward(address _rewardee, uint _reward) external onlyRR {
+    function transferWeiReward(address _rewardee, uint _reward) external onlyTRorRR {
         require(_reward <= weiBal);
         weiBal -= _reward;
         _rewardee.transfer(_reward);

--- a/contracts/Project.sol
+++ b/contracts/Project.sol
@@ -76,9 +76,11 @@ contract Project {
     uint256 public proposerStake;
     uint256 public weiBal;
     uint256 public nextDeadline;
+    uint256 public proposedCost;
+    uint256 public validationReward;
     uint256 public weiCost;
     uint256 public reputationCost;
-    uint256 public validationReward;
+
     bytes public ipfsHash;
 
     uint256 public tokensStaked;
@@ -165,7 +167,8 @@ contract Project {
         tokenRegistryAddress = _tokenRegistry;
         projectRegistryAddress = msg.sender;
         validationReward = _cost * 5 / 100;
-        weiCost = _cost + validationReward;
+        proposedCost = _cost;
+        weiCost = proposedCost + validationReward;
 
         // This is broken math
         reputationCost = _costProportion * ReputationRegistry(_reputationRegistry).totalSupply() / 10000000000;

--- a/contracts/Project.sol
+++ b/contracts/Project.sol
@@ -38,9 +38,7 @@ contract Project {
       uint validateStatePeriod,
       uint voteCommitPeriod,
       uint voteRevealPeriod,
-      uint passThreshold,
-      uint proposerCost,
-      uint validationReward
+      uint passThreshold
     );
 
     // =====================================================================
@@ -203,8 +201,6 @@ contract Project {
           voteCommitPeriod,
           voteRevealPeriod,
           passThreshold
-          proposedCost,
-          validateReward
         );
 
     }

--- a/contracts/ProjectLibrary.sol
+++ b/contracts/ProjectLibrary.sol
@@ -210,7 +210,7 @@ library ProjectLibrary {
                 Task task = Task(project.tasks(i));
                 if (task.complete()) {
                     // require that one of the indexes is not zero, meaning that a validator existss
-                    require(task.affrimativeIndex() != 0 || task.negativeIndex() != 0);
+                    require(task.affirmativeIndex() != 0 || task.negativeIndex() != 0);
                     if (task.affirmativeIndex() != 0 && task.negativeIndex() != 0) { // there is an opposing validator, poll required
                         uint pollNonce = plcr.startPoll(51, project.voteCommitPeriod(), project.voteRevealPeriod());
                         task.setPollId(pollNonce); // function handles storage of voting pollId
@@ -218,7 +218,7 @@ library ProjectLibrary {
                         if (task.negativeIndex() == 0) {
                           task.markTaskClaimable(true);
                         } else {
-                          task.markTaskClaimable(false)
+                          task.markTaskClaimable(false);
                           uint reward = task.weiReward();
                           tr.revertWei(reward);
                           project.returnWei(_distributeTokenAddress, reward);
@@ -259,7 +259,7 @@ library ProjectLibrary {
             PLCRVoting plcr = PLCRVoting(_plcrVoting);
             for (uint i = 0; i < project.getTaskCount(); i++) {
                 Task task = Task(project.tasks(i));
-                if (task.pollId()) {      // check tasks with polls only
+                if (task.pollId() != 0) {      // check tasks with polls only
                     if (plcr.pollEnded(task.pollId())) {
                         if (plcr.isPassed(task.pollId())) {
                             task.markTaskClaimable(true);
@@ -290,8 +290,7 @@ library ProjectLibrary {
     `_validator` can validate either approve or deny, with `tokens` tokens.
     @param _projectAddress Address of the project
     @param _validator Address of the validator
-    @param _index Index of the task in the projects task array
-    @param _tokens Amount of tokens validator is staking
+    @param _taskIndex Index of the task in the projects task array
     @param _validationState Bool representing validators choice.s
     */
     function validate(
@@ -337,6 +336,7 @@ library ProjectLibrary {
     transfers the wei reward to the task claimer. Returns the reputation reward for the claimer.
     @param _projectAddress Address of the project
     @param _index Index of the task in project task array
+    @param _claimer Address of account claiming task reward.
     @return The amount of reputation the claimer staked on the task
     */
     function claimTaskReward(

--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -56,7 +56,7 @@ contract ProjectRegistry {
 
     mapping (address => StakedState) public stakedProjects;
 
-    uint256[5] validationRewardWeightings = [36, 24, 17, 13, 10];
+    uint[5] public validationRewardWeightings = [36, 24, 17, 13, 10];
 
     // =====================================================================
     // MODIFIERS

--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -418,7 +418,7 @@ contract ProjectRegistry {
     /**
     @notice Claim a task at index `_index` from project at `_projectAddress` with description
     `_taskDescription`, weighting `_weighting` by claimer `_claimer. Set the ether reward of the task
-    to `_weiVal` and the repuation needed to claim the task to `_reputationVal`
+    to `_weiVal` and the reputation needed to claim the task to `_reputationVal`
     @dev Only callable by the ReputationRegistry
     @param _projectAddress Address of project
     @param _index Index of the task in task array.

--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.21;
 import "./library/PLCRVoting.sol";
 /* import "./library/ProxyFactory.sol"; */
 import "./ReputationRegistry.sol";
+import "./DistributeToken.sol";
 /* import "./Project.sol"; */
 import "./ProjectLibrary.sol";
 import "./Task.sol";
@@ -54,6 +55,8 @@ contract ProjectRegistry {
     }
 
     mapping (address => StakedState) public stakedProjects;
+
+    uint256[5] validationRewardWeightings = [36, 24, 17, 13, 10];
 
     // =====================================================================
     // MODIFIERS
@@ -460,10 +463,11 @@ contract ProjectRegistry {
     function submitTaskComplete(address _projectAddress, uint256 _index) external {
         Project project = Project(_projectAddress);
         Task task = Task(project.tasks(_index));
+        DistributeToken dt = DistributeToken(distributeTokenAddress);
         require(task.claimer() == msg.sender);
         require(task.complete() == false);
         require(project.state() == 3);
-
+        task.setValidationEntryFee((task.weighting() * project.weiCost() / 100) / dt.currentPrice());
         task.markTaskComplete();
     }
 }

--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -336,7 +336,7 @@ contract ProjectRegistry {
         require(project.proposerStake() > 0);
 
         uint256[2] memory returnValues;
-        returnValues[0] = project.weiCost();
+        returnValues[0] = project.proposedCost();
         returnValues[1] = project.proposerStake();
         project.clearProposerStake();
         return returnValues;
@@ -467,7 +467,7 @@ contract ProjectRegistry {
         require(task.claimer() == msg.sender);
         require(task.complete() == false);
         require(project.state() == 3);
-        task.setValidationEntryFee((task.weighting() * project.weiCost() / 100) / dt.currentPrice());
+        task.setValidationEntryFee((task.weighting() * project.proposedCost() / 100) / dt.currentPrice());
         task.markTaskComplete();
     }
 }

--- a/contracts/ReputationRegistry.sol
+++ b/contracts/ReputationRegistry.sol
@@ -233,7 +233,7 @@ contract ReputationRegistry {
         require(project.hashListSubmitted() == true);
         uint reputationVal = project.reputationCost() * _weighting / 100;   // does this need SafeMath?
         require(balances[msg.sender] >= reputationVal);
-        uint weiVal = project.weiCost() * _weighting / 100;     // does this need SafeMath?
+        uint weiVal = project.proposedCost() * _weighting / 100;
         balances[msg.sender] -= reputationVal;
         projectRegistry.claimTask(
             _projectAddress,

--- a/contracts/ReputationRegistry.sol
+++ b/contracts/ReputationRegistry.sol
@@ -34,6 +34,9 @@ contract ReputationRegistry {
         address indexed registree
     );
 
+    event LogStakedReputation(address indexed projectAddress, uint256 reputation, address staker);
+    event LogUnstakedReputation(address indexed projectAddress, uint256 reputation, address unstaker);
+
     // =====================================================================
     // STATE VARIABLES
     // =====================================================================
@@ -102,7 +105,7 @@ contract ReputationRegistry {
 
     /**
     @notice Register an account `msg.sender` for the first time in the reputation registry, grant 10,000
-    repuation to start.
+    reputation to start.
     @dev Has no sybil protection, thus a user can auto generate accounts to receive excess reputation.
     */
     function register() external {
@@ -186,6 +189,7 @@ contract ReputationRegistry {
         balances[msg.sender] -= reputationVal;
         Project(_projectAddress).stakeReputation(msg.sender, reputationVal);
         projectRegistry.checkStaked(_projectAddress);
+        emit LogStakedReputation(_projectAddress, _reputation, msg.sender);
     }
 
     /**
@@ -202,6 +206,7 @@ contract ReputationRegistry {
 
         balances[msg.sender] += _reputation;
         Project(_projectAddress).unstakeReputation(msg.sender, _reputation);
+        emit LogUnstakedReputation(_projectAddress, _reputation, msg.sender);
     }
 
     // =====================================================================

--- a/contracts/ReputationRegistry.sol
+++ b/contracts/ReputationRegistry.sol
@@ -141,7 +141,7 @@ contract ReputationRegistry {
         require(balances[msg.sender] >= proposerReputationCost);
 
         balances[msg.sender] -= proposerReputationCost;
-        address projectAddress = projectRegistry.createProject(
+        projectRegistry.createProject(
             _cost,
             costProportion,
             _stakingPeriod,

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -45,6 +45,7 @@ contract Task {
     struct Validator {
         uint256 status;
         uint256 index;
+        bool initialized;
     }
 
     /* bool public opposingValidator = false;
@@ -142,17 +143,17 @@ contract Task {
     @param _validationVal Flag for positive or negative validation
     */
     function setValidator(address _validator, uint256 _validationVal) external onlyTR {
-        require(validators[_validator] == 0);
+        require(!validators[_validator].initialized);
         require(_validationVal == 1 || _validationVal == 0);
         if (_validationVal == 1) {
           require(affirmativeIndex < 5);
           affirmativeValidators[affirmativeIndex] = _validator;
-          validators[_validator] = Validator(_validationVal, affirmativeIndex);
+          validators[_validator] = Validator(_validationVal, affirmativeIndex, true);
           affirmativeIndex += 1;
         } else {
           require(negativeIndex < 5);
           negativeValidators[negativeIndex] = _validator;
-          validators[_validator] = Validator(_validationVal, negativeIndex);
+          validators[_validator] = Validator(_validationVal, negativeIndex, true);
           negativeIndex += 1;
         }
     }
@@ -184,7 +185,7 @@ contract Task {
     @param _validator Address of validator
     */
     function getValidatorStatus(address _validator) external view returns (uint) {
-      require(validators[_validator] != 0);
+      require(validators[_validator].initialized);
       return validators[_validator].status;
     }
 
@@ -192,8 +193,8 @@ contract Task {
     @notice Return the validator validationindex of validator at `_validator`
     @param _validator Address of validator
     */
-    function getVaidatorIndex(address _validator) external view returns (uint) {
-      require(validators[_validator] != 0);
+    function getValidatorIndex(address _validator) external view returns (uint) {
+      require(validators[_validator].initialized);
       return validators[_validator].index;
     }
 

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -34,17 +34,22 @@ contract Task {
     bool public complete;
     address public claimer;
 
+    mapping (address => Validator) public validators;
+    uint256 public validateReward;
+    uint public validationEntryFee;
+    address[5] public affirmativeValidators;
+    uint public affirmativeIndex;
+    address[5] public negativeValidators;
+    uint public negativeIndex;
+
     struct Validator {
         uint256 status;
-        uint256 stake;
+        uint256 index;
     }
 
-    bool public opposingValidator = false;
-    uint256 public validateReward;
-
-    mapping (address => Validator) public validators;
+    /* bool public opposingValidator = false;
     uint256 public totalValidateAffirmative;
-    uint256 public totalValidateNegative;
+    uint256 public totalValidateNegative; */
 
     // =====================================================================
     // MODIFIERS
@@ -123,21 +128,32 @@ contract Task {
     }
 
     /**
-    @notice Set validator of the current task, if the validator is of a different type than the other
-    validators i.e. No when there are only Yes validators, then sets opposingValidator to true.
+    @notice Sets the entry fee for validation
+    @dev Only callable by the Project Registry
+    */
+    function setValidationEntryFee(uint256 _entryFee) external onlyPR {
+        validationEntryFee = _entryFee;
+    }
+
+    /**
+    @notice Set a validator of the current task,
     @dev Only callable by the Token Registry
     @param _validator Address of validator
     @param _validationVal Flag for positive or negative validation
-    @param _tokens Amount of tokens to stake on Validation.
     */
-    function setValidator(address _validator, uint256 _validationVal, uint256 _tokens) external onlyTR {
-        require(validators[_validator].stake == 0);
-        validators[_validator] = Validator(_validationVal, _tokens);
-        _validationVal == 1
-            ? totalValidateAffirmative += _tokens
-            : totalValidateNegative += _tokens;
-        if (!opposingValidator && (totalValidateAffirmative != 0 && totalValidateNegative != 0)) {
-            opposingValidator = true;
+    function setValidator(address _validator, uint256 _validationVal) external onlyTR {
+        require(validators[_validator] == 0);
+        require(_validationVal == 1 || _validationVal == 0);
+        if (_validationVal == 1) {
+          require(affirmativeIndex < 5);
+          affirmativeValidators[affirmativeIndex] = _validator;
+          validators[_validator] = Validator(_validationVal, affirmativeIndex);
+          affirmativeIndex += 1;
+        } else {
+          require(negativeIndex < 5);
+          negativeValidators[negativeIndex] = _validator;
+          validators[_validator] = Validator(_validationVal, negativeIndex);
+          negativeIndex += 1;
         }
     }
 
@@ -157,44 +173,37 @@ contract Task {
     @dev Only callable by the ProjectRegistry
     @param _passed Boolean describing the validation state the task should be claimable for.
     */
-    function markTaskClaimable(bool _passed) external onlyPR returns (bool) {             // passed only matters in voting
-        if (totalValidateAffirmative == 0 || totalValidateNegative == 0) {
-            claimable = true;
-            if (totalValidateAffirmative > totalValidateNegative) { claimableByRep = true; }
-        } else {
-            claimable = true;
-            if (_passed) {
-                claimableByRep = true;
-                totalValidateNegative = 0;
-            } else {
-                totalValidateAffirmative = 0;
-            }
-        }
+    function markTaskClaimable(bool _passed) external onlyPR returns (bool) {
+        claimable = true;            // passed only matters in voting
+        if (_passed) { claimableByRep = true; }
         return claimableByRep;
     }
 
     /**
-    @notice Return the validator status of validator at `_validator`
+    @notice Return the validator status (affrimative of negative) of validator at `_validator`
     @param _validator Address of validator
     */
     function getValidatorStatus(address _validator) external view returns (uint) {
+      require(validators[_validator] != 0);
       return validators[_validator].status;
     }
 
     /**
-    @notice Clear the validator stake of validator at `_validator`
+    @notice Return the validator validationindex of validator at `_validator`
     @param _validator Address of validator
     */
-    function getValidatorStake(address _validator) external view returns (uint) {
-      return validators[_validator].stake;
+    function getVaidatorIndex(address _validator) external view returns (uint) {
+      require(validators[_validator] != 0);
+      return validators[_validator].index;
     }
+
 
     /**
     @notice Clear the validator stake of validator at `_validator`
     @dev Only callable by TokenRegistry
     @param _validator Address of validator
     */
-    function clearValidatorStake(address _validator) external onlyTR {
-        validators[_validator].stake = 0;
+    function setValidatorIndex(address _validator) external onlyTR {
+        validators[_validator].index = 100;
     }
 }

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -25,8 +25,8 @@ contract TokenRegistry {
     // EVENTS
     // =====================================================================
 
-    event LogStakedTokens(address indexed projectAddress, uint256 tokens, address staker);
-    event LogUnstakedTokens(address indexed projectAddress, uint256 tokens, address unstaker);
+    event LogStakedTokens(address indexed projectAddress, uint256 tokens, uint256 weiChange, address staker);
+    event LogUnstakedTokens(address indexed projectAddress, uint256 tokens, uint256 weiChange, address unstaker);
 
     // =====================================================================
     // STATE VARIABLES

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -103,7 +103,7 @@ contract TokenRegistry {
         require(distributeToken.balanceOf(msg.sender) >= proposerTokenCost);
 
         distributeToken.transferToEscrow(msg.sender, proposerTokenCost);
-        address projectAddress = projectRegistry.createProject(
+        projectRegistry.createProject(
             _cost,
             costProportion,
             _stakingPeriod,
@@ -198,18 +198,17 @@ contract TokenRegistry {
     tokens for validation state `_validationState`
     @dev Requires the token balance of msg.sender to be greater than the reputationVal of the task
     @param _projectAddress Address of the project
-    @param _index Index of the task
-    @param _tokens Amount of tokens to stake on the validation state
+    @param _taskIndex Index of the task
     @param _validationState Approve or Deny task
     */
     function validateTask(
         address _projectAddress,
-        uint256 _index,
+        uint256 _taskIndex,
         bool _validationState
     ) external {
         require(projectRegistry.projects(_projectAddress) == true);
         Project project = Project(_projectAddress);
-        Task task = Task(project.tasks(_index));
+        Task task = Task(project.tasks(_taskIndex));
         uint256 validationFee = task.validationEntryFee();
         require(distributeToken.balanceOf(msg.sender) >= validationFee);
         distributeToken.transferToEscrow(msg.sender, validationFee);
@@ -227,19 +226,18 @@ contract TokenRegistry {
         Task task = Task(project.tasks(_index));
         require(task.claimable());
         uint returnAmount;
-        uint status = task.getValidatorStatus(msg.sender);
         uint index = task.getValidatorIndex(msg.sender);
-        uint entryFee = task.validationEntryFee()
         require(index < 5);
         task.setValidatorIndex(msg.sender);
         uint rewardWeighting = projectRegistry.validationRewardWeightings(index);
-        uint statusNeed = task.claimableByRep() ? 1 : 0
-        if (statusNeed == status) {
-            returnAmount += entryFee;
+        uint statusNeed = task.claimableByRep() ? 1 : 0;
+
+        if (statusNeed == task.getValidatorStatus(msg.sender)) {
+            returnAmount += task.validationEntryFee();
             uint validationIndex;
-            if (status) {
+            if (task.getValidatorStatus(msg.sender) == 1) {
               require(task.affirmativeValidators(index) == msg.sender);
-              validationIndex = task.affrimativeIndex();
+              validationIndex = task.affirmativeIndex();
             } else {
               require(task.negativeValidators(index) == msg.sender);
               validationIndex = task.negativeIndex();
@@ -247,17 +245,17 @@ contract TokenRegistry {
             if (validationIndex < 5) {
                 uint addtlWeighting;
                 for(uint i = validationIndex; i < 5; i++) {
-                    addtlWeighting += projectRegisty.validationRewardWeightings(i);
+                    addtlWeighting += projectRegistry.validationRewardWeightings(i);
                 }
-                rewardWeighting += addtionalWeighting / validationIndex;
+                rewardWeighting += addtlWeighting / validationIndex;
             }
             project.transferWeiReward(msg.sender, ((project.validationReward() * task.weighting() / 100) * rewardWeighting / 100));
         } else {
             statusNeed == 1
                 ? require(task.negativeValidators(index) == msg.sender)
                 : require(task.affirmativeValidators(index) == msg.sender);
-            returnAmount += task.validationEntryFee / 2;
-            distributeToken.burn(entryFee - returnAmount);
+            returnAmount += task.validationEntryFee() / 2;
+            distributeToken.burn(task.validationEntryFee() - returnAmount);
         }
         distributeToken.transferFromEscrow(msg.sender, returnAmount);
     }

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -25,6 +25,9 @@ contract TokenRegistry {
     // EVENTS
     // =====================================================================
 
+    event LogStakedTokens(address indexed projectAddress, uint256 tokens, address staker);
+    event LogUnstakedTokens(address indexed projectAddress, uint256 tokens, address unstaker);
+
     // =====================================================================
     // STATE VARIABLES
     // =====================================================================
@@ -164,6 +167,7 @@ contract TokenRegistry {
         distributeToken.transferWeiTo(_projectAddress, weiChange);      // A and S are confused - why is this here/what is it doing?
         distributeToken.transferToEscrow(msg.sender, tokens);
         projectRegistry.checkStaked(_projectAddress);
+        emit LogStakedTokens(_projectAddress, _tokens, msg.sender);
     }
 
     /**
@@ -182,6 +186,7 @@ contract TokenRegistry {
         // the weiBal is updated via the next line
         distributeToken.returnWei(weiVal);
         distributeToken.transferFromEscrow(msg.sender, _tokens);
+        emit LogUnstakedTokens(_projectAddress, _tokens, msg.sender);
     }
 
     // =====================================================================


### PR DESCRIPTION
Create 2 lots of 5 positions each. One for Affirmative Validation and One for Negative Validation. The earlier lots get a bigger percentage of the validation reward. Existing validators split the reward percentage of the remaining validation lots. Validators who validate incorrectly get half their tokens burned. Validation reward cost is calculated as 5% of the proposed cost and is added to the project weiCost.